### PR TITLE
feat: added ability to specify id for pc

### DIFF
--- a/src/NetworkScoresCalculator.ts
+++ b/src/NetworkScoresCalculator.ts
@@ -32,7 +32,7 @@ class NetworkScoresCalculator implements INetworkScoresCalculator {
     return {
       outbound,
       inbound,
-      pc: connectionId,
+      connectionId,
       statsSamples: {
         inboundStatsSample,
         outboundStatsSample,

--- a/src/NetworkScoresCalculator.ts
+++ b/src/NetworkScoresCalculator.ts
@@ -5,7 +5,6 @@ import {
   INetworkScoresCalculator,
   WebRTCStatsParsed,
   NetworkQualityStatsSample,
-  NetworkScoresPayload,
 } from './types';
 import { scheduleTask } from './utils/tasks';
 import { CLEANUP_PREV_STATS_TTL_MS } from './utils/constants';
@@ -18,7 +17,7 @@ type MosCalculatorResult = {
 class NetworkScoresCalculator implements INetworkScoresCalculator {
   #lastProcessedStats: { [connectionId: string]: WebRTCStatsParsed } = {};
 
-  calculate({ data, id }: NetworkScoresPayload): NetworkScores {
+  calculate(data: WebRTCStatsParsed): NetworkScores {
     const { connection: { id: connectionId } } = data;
     const { mos: outbound, stats: outboundStatsSample } = this.calculateOutboundScore(data) || {};
     const { mos: inbound, stats: inboundStatsSample } = this.calculateInboundScore(data) || {};
@@ -33,7 +32,7 @@ class NetworkScoresCalculator implements INetworkScoresCalculator {
     return {
       outbound,
       inbound,
-      id,
+      pc: connectionId,
       statsSamples: {
         inboundStatsSample,
         outboundStatsSample,

--- a/src/NetworkScoresCalculator.ts
+++ b/src/NetworkScoresCalculator.ts
@@ -5,6 +5,7 @@ import {
   INetworkScoresCalculator,
   WebRTCStatsParsed,
   NetworkQualityStatsSample,
+  NetworkScoresPayload,
 } from './types';
 import { scheduleTask } from './utils/tasks';
 import { CLEANUP_PREV_STATS_TTL_MS } from './utils/constants';
@@ -17,7 +18,7 @@ type MosCalculatorResult = {
 class NetworkScoresCalculator implements INetworkScoresCalculator {
   #lastProcessedStats: { [connectionId: string]: WebRTCStatsParsed } = {};
 
-  calculate(data: WebRTCStatsParsed): NetworkScores {
+  calculate({ data, id }: NetworkScoresPayload): NetworkScores {
     const { connection: { id: connectionId } } = data;
     const { mos: outbound, stats: outboundStatsSample } = this.calculateOutboundScore(data) || {};
     const { mos: inbound, stats: inboundStatsSample } = this.calculateInboundScore(data) || {};
@@ -32,6 +33,7 @@ class NetworkScoresCalculator implements INetworkScoresCalculator {
     return {
       outbound,
       inbound,
+      id,
       statsSamples: {
         inboundStatsSample,
         outboundStatsSample,

--- a/src/WebRTCIssueDetector.ts
+++ b/src/WebRTCIssueDetector.ts
@@ -85,7 +85,7 @@ class WebRTCIssueDetector {
       this.wrapRTCPeerConnection();
     }
 
-    this.statsReporter.on(PeriodicWebRTCStatsReporter.STATS_REPORT_READY_EVENT, (report : StatsReportItem) => {
+    this.statsReporter.on(PeriodicWebRTCStatsReporter.STATS_REPORT_READY_EVENT, (report: StatsReportItem) => {
       this.detectIssues({
         data: report.stats,
       });
@@ -159,8 +159,8 @@ class WebRTCIssueDetector {
     }
   }
 
-  private calculateNetworkScores(payload: WebRTCStatsParsed): void {
-    const networkScores = this.networkScoresCalculator.calculate(payload);
+  private calculateNetworkScores(data: WebRTCStatsParsed): void {
+    const networkScores = this.networkScoresCalculator.calculate(data);
     this.eventEmitter.emit(EventType.NetworkScoresUpdated, networkScores);
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -108,7 +108,7 @@ export type NetworkQualityStatsSample = {
 export type NetworkScores = {
   outbound?: NetworkScore,
   inbound?: NetworkScore,
-  pc?: string,
+  connectionId?: string,
   statsSamples: {
     outboundStatsSample?: NetworkQualityStatsSample,
     inboundStatsSample?: NetworkQualityStatsSample,

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,7 +15,7 @@ export interface IssueDetector {
 }
 
 export interface INetworkScoresCalculator {
-  calculate(data: NetworkScoresPayload): NetworkScores;
+  calculate(data: WebRTCStatsParsed): NetworkScores;
 }
 
 export enum EventType {
@@ -105,15 +105,10 @@ export type NetworkQualityStatsSample = {
   packetsLoss: number;
 };
 
-export type NetworkScoresPayload = {
-  data: WebRTCStatsParsed,
-  id?: string;
-};
-
 export type NetworkScores = {
   outbound?: NetworkScore,
   inbound?: NetworkScore,
-  id?: string;
+  pc?: string,
   statsSamples: {
     outboundStatsSample?: NetworkQualityStatsSample,
     inboundStatsSample?: NetworkQualityStatsSample,

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,7 +15,7 @@ export interface IssueDetector {
 }
 
 export interface INetworkScoresCalculator {
-  calculate(data: WebRTCStatsParsed): NetworkScores;
+  calculate(data: NetworkScoresPayload): NetworkScores;
 }
 
 export enum EventType {
@@ -105,9 +105,15 @@ export type NetworkQualityStatsSample = {
   packetsLoss: number;
 };
 
+export type NetworkScoresPayload = {
+  data: WebRTCStatsParsed,
+  id?: string;
+};
+
 export type NetworkScores = {
   outbound?: NetworkScore,
   inbound?: NetworkScore,
+  id?: string;
   statsSamples: {
     outboundStatsSample?: NetworkQualityStatsSample,
     inboundStatsSample?: NetworkQualityStatsSample,


### PR DESCRIPTION
Discussed issue [here](https://github.com/VLprojects/webrtc-issue-detector/issues/20)

Added new optional `id?: string` param in `handleNewPeerConnection` method and emited the `id` back in callback `calculateNetworkScores`, so now developers can use it that way

```js
webRTCIssueDetector.handleNewPeerConnection(pc, 'some-id-1')
webRTCIssueDetector.handleNewPeerConnection(pc, 'some-id-2')
webRTCIssueDetector.handleNewPeerConnection(pc, 'some-id-3')
```

and in callback it wil be

```js
onNetworkScoresUpdated: (scores) => scores.id; // some-id-X
```


@evgmel @desher @panov-va please take a look
