### PR TITLE
feat: Add configurable params for detectors that could support them

### DIFF
--- a/src/detectors/InboundNetworkIssueDetector.ts
+++ b/src/detectors/InboundNetworkIssueDetector.ts
@@ -6,7 +6,7 @@ import {
 } from '../types';
 import BaseIssueDetector, { BaseIssueDetectorParams } from './BaseIssueDetector';
 
-interface InboundNetworkIssueDetectorParams extends BaseIssueDetectorParams {
+export interface InboundNetworkIssueDetectorParams extends BaseIssueDetectorParams {
   highPacketLossThresholdPct?: number;
   highJitterThreshold?: number;
   highJitterBufferDelayThresholdMs?: number;

--- a/src/detectors/InboundNetworkIssueDetector.ts
+++ b/src/detectors/InboundNetworkIssueDetector.ts
@@ -4,9 +4,9 @@ import {
   IssueType,
   WebRTCStatsParsed,
 } from '../types';
-import BaseIssueDetector from './BaseIssueDetector';
+import BaseIssueDetector, { BaseIssueDetectorParams } from './BaseIssueDetector';
 
-export interface InboundNetworkIssueDetectorParams {
+interface InboundNetworkIssueDetectorParams extends BaseIssueDetectorParams {
   highPacketLossThresholdPct?: number;
   highJitterThreshold?: number;
   highJitterBufferDelayThresholdMs?: number;
@@ -14,20 +14,17 @@ export interface InboundNetworkIssueDetectorParams {
 }
 
 class InboundNetworkIssueDetector extends BaseIssueDetector {
-  readonly highPacketLossThresholdPct: number;
-
-  readonly highJitterThreshold: number;
-
-  readonly highJitterBufferDelayThresholdMs: number;
-
-  readonly highRttThresholdMs: number;
+  readonly #highPacketLossThresholdPct: number;
+  readonly #highJitterThreshold: number;
+  readonly #highJitterBufferDelayThresholdMs: number;
+  readonly #highRttThresholdMs: number;
 
   constructor(params: InboundNetworkIssueDetectorParams = {}) {
     super();
-    this.highPacketLossThresholdPct = params.highPacketLossThresholdPct ?? 5;
-    this.highJitterThreshold = params.highJitterThreshold ?? 200;
-    this.highJitterBufferDelayThresholdMs = params.highJitterBufferDelayThresholdMs ?? 500;
-    this.highRttThresholdMs = params.highRttThresholdMs ?? 250;
+    this.#highPacketLossThresholdPct = params.highPacketLossThresholdPct ?? 5;
+    this.#highJitterThreshold = params.highJitterThreshold ?? 200;
+    this.#highJitterBufferDelayThresholdMs = params.highJitterBufferDelayThresholdMs ?? 500;
+    this.#highRttThresholdMs = params.highRttThresholdMs ?? 250;
   }
 
   performDetection(data: WebRTCStatsParsed): IssueDetectorResult {
@@ -87,10 +84,10 @@ class InboundNetworkIssueDetector extends BaseIssueDetector {
       ? Math.round((deltaPacketLost * 100) / (deltaPacketReceived + deltaPacketLost))
       : 0;
 
-    const isHighPacketsLoss = packetLossPct > this.highPacketLossThresholdPct;
-    const isHighJitter = avgJitter >= this.highJitterThreshold;
-    const isHighRTT = rtt >= this.highRttThresholdMs;
-    const isHighJitterBufferDelay = avgJitterBufferDelay > this.highJitterBufferDelayThresholdMs;
+    const isHighPacketsLoss = packetLossPct > this.#highPacketLossThresholdPct;
+    const isHighJitter = avgJitter >= this.#highJitterThreshold;
+    const isHighRTT = rtt >= this.#highRttThresholdMs;
+    const isHighJitterBufferDelay = avgJitterBufferDelay > this.#highJitterBufferDelayThresholdMs;
     const isNetworkIssue = isHighJitter || isHighPacketsLoss;
     const isServerIssue = isHighRTT && !isHighJitter && !isHighPacketsLoss;
     const isNetworkMediaLatencyIssue = isHighPacketsLoss && isHighJitter;

--- a/src/detectors/InboundNetworkIssueDetector.ts
+++ b/src/detectors/InboundNetworkIssueDetector.ts
@@ -15,8 +15,11 @@ export interface InboundNetworkIssueDetectorParams extends BaseIssueDetectorPara
 
 class InboundNetworkIssueDetector extends BaseIssueDetector {
   readonly #highPacketLossThresholdPct: number;
+
   readonly #highJitterThreshold: number;
+
   readonly #highJitterBufferDelayThresholdMs: number;
+
   readonly #highRttThresholdMs: number;
 
   constructor(params: InboundNetworkIssueDetectorParams = {}) {

--- a/src/detectors/NetworkMediaSyncIssueDetector.ts
+++ b/src/detectors/NetworkMediaSyncIssueDetector.ts
@@ -4,9 +4,20 @@ import {
   IssueType,
   WebRTCStatsParsed,
 } from '../types';
-import BaseIssueDetector from './BaseIssueDetector';
+import BaseIssueDetector, { BaseIssueDetectorParams } from './BaseIssueDetector';
+
+interface NetworkMediaSyncIssueDetectorParams extends BaseIssueDetectorParams {
+  correctedSamplesThresholdPct?: number
+}
 
 class NetworkMediaSyncIssueDetector extends BaseIssueDetector {
+  readonly #correctedSamplesThresholdPct: number;
+
+  constructor(params: NetworkMediaSyncIssueDetectorParams = {}) {
+    super();
+    this.#correctedSamplesThresholdPct = params.correctedSamplesThresholdPct ?? 5;
+  }
+
   performDetection(data: WebRTCStatsParsed): IssueDetectorResult {
     const { connection: { id: connectionId } } = data;
     const issues = this.processData(data);
@@ -45,7 +56,7 @@ class NetworkMediaSyncIssueDetector extends BaseIssueDetector {
         correctedSamplesPct,
       };
 
-      if (correctedSamplesPct > 5) {
+      if (correctedSamplesPct > this.#correctedSamplesThresholdPct) {
         issues.push({
           statsSample,
           type: IssueType.Network,

--- a/src/detectors/OutboundNetworkIssueDetector.ts
+++ b/src/detectors/OutboundNetworkIssueDetector.ts
@@ -13,6 +13,7 @@ interface OutboundNetworkIssueDetectorParams extends BaseIssueDetectorParams {
 
 class OutboundNetworkIssueDetector extends BaseIssueDetector {
   readonly #highPacketLossThresholdPct: number;
+
   readonly #highJitterThreshold: number;
 
   constructor(params: OutboundNetworkIssueDetectorParams = {}) {


### PR DESCRIPTION
Implementation for issue https://github.com/VLprojects/webrtc-issue-detector/issues/23!

Also makes the `InboundNetworkIssueDetector` a little more consistent with other detectors by using private instance variables.