### PR TITLE
feat: keep last N processed stats

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,2 +1,3 @@
-// eslint-disable-next-line import/prefer-default-export
 export const CLEANUP_PREV_STATS_TTL_MS = 35_000;
+
+export const MAX_PARSED_STATS_STORAGE_SIZE = 5;


### PR DESCRIPTION
In case the detector needs more historical data than just the latest. Required for future detectors improvements.