### PR TITLE
fix: ignore dtx streams

### DIFF
--- a/src/detectors/FrozenVideoTrackDetector.ts
+++ b/src/detectors/FrozenVideoTrackDetector.ts
@@ -1,3 +1,4 @@
+import { isDtxLikeBehavior } from '../helpers/streams';
 import {
   IssueDetectorResult,
   IssueReason,
@@ -68,6 +69,12 @@ class FrozenVideoTrackDetector extends BaseIssueDetector {
         ]);
 
         if (isSpatialLayerChanged) {
+          return undefined;
+        }
+
+        const isDtx = isDtxLikeBehavior(videoStream.ssrc, allLastProcessedStats);
+        if (isDtx) {
+          // DTX-like behavior detected, ignoring freezes check
           return undefined;
         }
 

--- a/src/detectors/VideoDecoderIssueDetector.ts
+++ b/src/detectors/VideoDecoderIssueDetector.ts
@@ -1,4 +1,5 @@
 import { calculateVolatility } from '../helpers/calc';
+import { isDtxLikeBehavior } from '../helpers/streams';
 import {
   IssueDetectorResult,
   IssueReason,
@@ -81,6 +82,12 @@ class VideoDecoderIssueDetector extends BaseIssueDetector {
         }
 
         if (allFps.length < MIN_STATS_HISTORY_LENGTH) {
+          return undefined;
+        }
+
+        const isDtx = isDtxLikeBehavior(incomeVideoStream.ssrc, allProcessedStats);
+        if (isDtx) {
+          // DTX-like behavior detected, ignoring FPS volatility check
           return undefined;
         }
 

--- a/src/helpers/calc.ts
+++ b/src/helpers/calc.ts
@@ -1,5 +1,14 @@
 export const calculateMean = (values: number[]) => values.reduce((acc, val) => acc + val, 0) / values.length;
 
+export const calculateVariance = (mean: number, values: number[]) => values
+  .reduce((sum, val) => sum + (val - mean) ** 2, 0) / values.length;
+
+export const calculateStandardDeviation = (values: number[]) => {
+  const mean = calculateMean(values);
+  const variance = calculateVariance(mean, values);
+  return Math.sqrt(variance);
+};
+
 export const calculateVolatility = (values: number[]) => {
   if (values.length === 0) {
     throw new Error('Cannot calculate volatility for empty array');

--- a/src/helpers/streams.ts
+++ b/src/helpers/streams.ts
@@ -1,0 +1,40 @@
+import { WebRTCStatsParsedWithNetworkScores } from '../types';
+
+export const isDtxLikeBehavior = (
+  ssrc: number,
+  allProcessedStats: WebRTCStatsParsedWithNetworkScores[],
+  stdDevThreshold = 30,
+): boolean => {
+  const frameIntervals: number[] = [];
+  for (let i = 0; i < allProcessedStats.length - 1; i += 1) {
+    const videoStreamStats = allProcessedStats[i].video.inbound.find(
+      (stream) => stream.ssrc === ssrc,
+    );
+
+    const previousVideoStreamStats = allProcessedStats[i - 1]?.video?.inbound?.find(
+      (stream) => stream.ssrc === ssrc,
+    );
+
+    if (!videoStreamStats || !previousVideoStreamStats) {
+      continue;
+    }
+
+    const deltaTime = videoStreamStats.timestamp - previousVideoStreamStats.timestamp;
+    const deltaFrames = videoStreamStats.framesDecoded - previousVideoStreamStats.framesDecoded;
+
+    if (deltaFrames > 0) {
+      const frameInterval = deltaTime / deltaFrames; // Average time per frame
+      frameIntervals.push(frameInterval);
+    }
+  }
+
+  if (frameIntervals.length <= 1) {
+    return false;
+  }
+
+  const mean = frameIntervals.reduce((a, b) => a + b, 0) / frameIntervals.length;
+  const variance = frameIntervals
+    .reduce((sum, val) => sum + (val - mean) ** 2, 0) / frameIntervals.length;
+  const stdDev = Math.sqrt(variance);
+  return stdDev > stdDevThreshold;
+};


### PR DESCRIPTION
Ignore streams encoded with DTX option due to high FPS volatility and false positive freezeCount results in WebRTC Stats.