### PR TITLE
docs: fix heading for UnknownVideoDecoderImplementationDetector in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ const exampleIssue = {
 }
 ```
 
-### VideoCodecMismatchDetector
+### UnknownVideoDecoderImplementationDetector
 Detects issues with decoding stream.
 ```js
 const exampleIssue = {


### PR DESCRIPTION
This PR updates the README.md to correct a heading:

- Replaces the incorrect `VideoCodecMismatchDetector` heading with the correct `UnknownVideoDecoderImplementationDetector`.

This ensures that documentation accurately reflects the available detectors and avoids confusion for library users.