### PR TITLE
fix(detectors): adjust default jitter threshold to 0.2s instead of 200s

### DIFF
--- a/src/detectors/InboundNetworkIssueDetector.ts
+++ b/src/detectors/InboundNetworkIssueDetector.ts
@@ -25,7 +25,7 @@ class InboundNetworkIssueDetector extends BaseIssueDetector {
   constructor(params: InboundNetworkIssueDetectorParams = {}) {
     super();
     this.#highPacketLossThresholdPct = params.highPacketLossThresholdPct ?? 5;
-    this.#highJitterThreshold = params.highJitterThreshold ?? 200;
+    this.#highJitterThreshold = params.highJitterThreshold ?? 0.2;
     this.#highJitterBufferDelayThresholdMs = params.highJitterBufferDelayThresholdMs ?? 500;
     this.#highRttThresholdMs = params.highRttThresholdMs ?? 250;
   }

--- a/src/detectors/OutboundNetworkIssueDetector.ts
+++ b/src/detectors/OutboundNetworkIssueDetector.ts
@@ -19,7 +19,7 @@ class OutboundNetworkIssueDetector extends BaseIssueDetector {
   constructor(params: OutboundNetworkIssueDetectorParams = {}) {
     super();
     this.#highPacketLossThresholdPct = params.highPacketLossThresholdPct ?? 5;
-    this.#highJitterThreshold = params.highJitterThreshold ?? 200;
+    this.#highJitterThreshold = params.highJitterThreshold ?? 0.2;
   }
 
   performDetection(data: WebRTCStatsParsed): IssueDetectorResult {


### PR DESCRIPTION
### Summary
The default jitter threshold in both `InboundNetworkIssueDetector` and `OutboundNetworkIssueDetector` was set to `200`, which corresponds to 200 seconds. Since jitter values are reported in seconds, this default was unrealistically high and prevented correct detection of network issues.

### Changes
- Updated the default `highJitterThreshold` from `200` to `0.2` (200 ms).
- Applied the fix consistently across inbound and outbound detectors.

### Why
With the previous default of 200s, jitter-related issues would never be detected in practice. Using `0.2s` (200 ms) aligns with realistic network conditions and makes the detectors functional.
