### PR TITLE
feat: include full frozen stream stats in FrozenVideoTrackDetector result

### DIFF
--- a/src/detectors/FrozenVideoTrackDetector.ts
+++ b/src/detectors/FrozenVideoTrackDetector.ts
@@ -110,6 +110,7 @@ class FrozenVideoTrackDetector extends BaseIssueDetector {
         reason: IssueReason.FrozenVideoTrack,
         statsSample: {
           ssrcs: frozenStreams.map((stream) => stream.ssrc),
+          streams: frozenStreams,
         },
       });
 


### PR DESCRIPTION
### Summary
`FrozenVideoTrackDetector` previously reported only SSRCs of frozen streams in the `statsSample`.  
This PR extends the output to include the full frozen stream objects, which contain additional properties such as:
- `avgFreezeDurationMs`
- `frozenDurationPct`

### Why
These extra fields are very useful for debugging and monitoring, since they expose the actual measured freeze durations instead of just identifiers.  
The change is backwards-compatible because the `ssrcs` array is still included.

### Possible follow-up
If the team prefers more control, I could make this behavior optional by introducing a `verbose` (or similar) flag in the detector’s constructor. This would allow toggling between minimal and detailed output without changing existing integrations.
